### PR TITLE
Set image DPI to 300 when saving output

### DIFF
--- a/NFC-Card-Generator/nfc-card-generator.py
+++ b/NFC-Card-Generator/nfc-card-generator.py
@@ -1817,7 +1817,7 @@ class App(tk.Tk):
         ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         filename = "_".join(parts) + f"_{ts}.png"
 
-        self.output_image.save(os.path.join(self.output_dir, filename))
+        self.output_image.save(os.path.join(self.output_dir, filename), dpi=(300,300))
         self.show_status("Image saved")
 
     def save_as(self):


### PR DESCRIPTION
Printing these as-is would scale to 72dpi (full letter page, basically)
This patch sets the image metadata to 300dpi so they print "out of the box" at the proper size. Tested locally, seems to work just fine.